### PR TITLE
unclear message when gdb is not installed

### DIFF
--- a/pyringe/inferior.py
+++ b/pyringe/inferior.py
@@ -153,23 +153,23 @@ class GdbProxy(object):
     self._errfile_r = open(errfile_w.name)
 
     if self.is_installed:
-        self._process = subprocess.Popen(
-            bufsize=0,
-            args=arglist,
-            stdin=subprocess.PIPE,
-            stdout=outfile_w.file,
-            stderr=errfile_w.file,
-            close_fds=True,
-            preexec_fn=os.setpgrp,
-        )
-        outfile_w.close()
-        errfile_w.close()
+      self._process = subprocess.Popen(
+        bufsize=0,
+        args=arglist,
+        stdin=subprocess.PIPE,
+        stdout=outfile_w.file,
+        stderr=errfile_w.file,
+        close_fds=True,
+        preexec_fn=os.setpgrp,
+      )
+      outfile_w.close()
+      errfile_w.close()
 
-        self._poller = select.poll()
-        self._poller.register(self._outfile_r.fileno(),
-                              select.POLLIN | select.POLLPRI)
-        self._poller.register(self._errfile_r.fileno(),
-                              select.POLLIN | select.POLLPRI)
+      self._poller = select.poll()
+      self._poller.register(self._outfile_r.fileno(),
+                            select.POLLIN | select.POLLPRI)
+      self._poller.register(self._errfile_r.fileno(),
+                            select.POLLIN | select.POLLPRI)
 
   def __getattr__(self, name):
     """Handles transparent proxying to gdb subprocess.
@@ -435,7 +435,7 @@ class Inferior(object):
     # when requested, make sure we have a gdb session to return
     # (in case it crashed at some point)
     if not self._gdb or not self._gdb.is_running:
-        self.StartGdb()
+      self.StartGdb()
     return self._gdb
 
   def StartGdb(self):

--- a/pyringe/inferior.py
+++ b/pyringe/inferior.py
@@ -206,14 +206,12 @@ class GdbProxy(object):
 
   @property
   def is_installed(self):
-      """
-      Check if gdb is installed
-      """
-      gdb_path = distutils.spawn.find_executable("gdb")
-      if not gdb_path:
-          raise OSError("I can not find gdb")
-      else:
-          return True
+    """ Check if gdb is installed """
+    gdb_path = distutils.spawn.find_executable("gdb")
+    if not gdb_path:
+      raise OSError("I can not find gdb")
+    else:
+      return True
 
   @property
   def is_running(self):


### PR DESCRIPTION
 When gdb is not installed pyringe returns unclear message. Gdb is not installed by default in MacOS 10.9 .
